### PR TITLE
fix doc build with old sphinx

### DIFF
--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -13,7 +13,7 @@ import sys, os
 #needs_sphinx = '1.0'
 extensions = [@SPHINX_EXTENSIONS@]
 templates_path = ['_templates']
-source_suffix = ['.rst']
+source_suffix = '.rst'
 master_doc = 'index'
 pygments_style = 'sphinx'
 


### PR DESCRIPTION
Only encountered on quite old RHEL 7 (python-sphinx 1.1.3)

```
Exception occurred:
  File "/usr/lib/python2.7/site-packages/sphinx/util/__init__.py", line 85, in get_matching_docs
    suffixpattern = '*' + suffix
TypeError: cannot concatenate 'str' and 'list' objects
```