### PR TITLE
fix [-Wincompatible-pointer-types] warning

### DIFF
--- a/src/libmemcachedprotocol/binary_handler.c
+++ b/src/libmemcachedprotocol/binary_handler.c
@@ -933,7 +933,7 @@ stat_command_handler(const void *cookie, protocol_binary_request_header *header,
                       .opaque = header->request.opaque,
                   },
           }};
-      rval = response_handler(cookie, header, &response);
+      rval = response_handler(cookie, header, (void *) &response);
     }
   } else {
     rval = PROTOCOL_BINARY_RESPONSE_UNKNOWN_COMMAND;


### PR DESCRIPTION
```
/builddir/build/BUILD/libmemcached-0ff88be3322a493773956028d4022d995f3cb193/src/libmemcachedprotocol/binary_handler.c: In function 'stat_command_handler':
/builddir/build/BUILD/libmemcached-0ff88be3322a493773956028d4022d995f3cb193/src/libmemcachedprotocol/binary_handler.c:936:47: warning: passing argument 3 of 'response_handler' from incompatible pointer type [-Wincompatible-pointer-types]
  936 |       rval = response_handler(cookie, header, &response);
      |                                               ^~~~~~~~~
      |                                               |
      |                                               protocol_binary_response_no_extras *
/builddir/build/BUILD/libmemcached-0ff88be3322a493773956028d4022d995f3cb193/src/libmemcachedprotocol/binary_handler.c:936:47: note: expected 'protocol_binary_response_header *' but argument is of type 'protocol_binary_response_no_extras *'

```


I apply a cast to `(void *) `for consistency with other calls, but a better way could be to use `&response.message.header`