### PR TITLE
re-add Paul Hsieh header

### DIFF
--- a/src/libhashkit/hsieh.cc
+++ b/src/libhashkit/hsieh.cc
@@ -13,6 +13,13 @@
     +--------------------------------------------------------------------+
 */
 
+/* By Paul Hsieh (C) 2004, 2005.  Covered under the Paul Hsieh
+ * derivative license.
+ * See: http://www.azillionmonkeys.com/qed/weblicense.html for license
+ * details.
+ * http://www.azillionmonkeys.com/qed/hash.html
+*/
+
 #include "libhashkit/common.h"
 
 #undef get16bits


### PR DESCRIPTION
Looks like this header disapear (by mystake) during a header cleanup

For memory, in the past the old [Paul Hsieh exposition license ](http://www.azillionmonkeys.com/qed/license-exposition.html) have issue, the reason why this hash was disabled in various distribution.

Things have changed

From [Paul Hsieh's web licenses](http://www.azillionmonkeys.com/qed/weblicense.html)

> For the specific coverage of raw source code (only) obtained from this website, you have the option of using the old-style
> BSD license to use the code instead of other the licenses. This option has been provided for people who can't figure out
> what I talking about with my derivative license, or who are using a old-style BSD compatible license.

So this code is now BSD, so no more issue with using it