### PR TITLE
If libcrypto implementation of AES is used, do not compile internal

### DIFF
--- a/src/libhashkit/CMakeLists.txt
+++ b/src/libhashkit/CMakeLists.txt
@@ -17,7 +17,6 @@ set(libhashkit_sources
         murmur3.cc
         murmur3_api.cc
         one_at_a_time.cc
-        rijndael.cc
         str_algorithm.cc
         strerror.cc
         string.cc
@@ -51,6 +50,10 @@ if(ENABLE_OPENSSL_CRYPTO)
                         message(WARNING "Could not find OpenSSL::Crypto")
                 endif()
         endif()
+endif()
+
+if (NOT OPENSSL_CRYPTO_LIBRARY)
+        set (libhashkit_sources ${libhashkit_sources} rijndael.cc)
 endif()
 
 configure_file(hashkitcon.h.in hashkitcon.h @ONLY)


### PR DESCRIPTION
Hi,
this is somewhat cosmetic change. When libcrypto implementation of
AES is used, rijndael.cc file does not have to be compiled and linked
into the library. This allows us to not list rijndael AES implementation
as bundled feature of libmemcached in Fedora and RHEL package.