### PR TITLE
Prevent underflow in `memcached_*_response_decrement` macros

### DIFF
--- a/src/libmemcached/common.h
+++ b/src/libmemcached/common.h
@@ -140,11 +140,21 @@ static inline void memcached_server_response_increment(memcached_instance_st *in
 }
 #endif
 
-#define memcached_server_response_decrement(A) (A)->cursor_active_--
-#define memcached_server_response_reset(A)     (A)->cursor_active_ = 0
+#define memcached_server_response_decrement(A) do {     \
+    WATCHPOINT_ASSERT((A)->cursor_active_ > 0);         \
+    if ((A)->cursor_active_ > 0) {                      \
+        (A)->cursor_active_--;                          \
+    }                                                   \
+} while (0)
+#define memcached_server_response_reset(A)       (A)->cursor_active_ = 0
 
 #define memcached_instance_response_increment(A) (A)->cursor_active_++
-#define memcached_instance_response_decrement(A) (A)->cursor_active_--
+#define memcached_instance_response_decrement(A) do {   \
+    WATCHPOINT_ASSERT((A)->cursor_active_ > 0);         \
+    if ((A)->cursor_active_ > 0) {                      \
+        (A)->cursor_active_--;                          \
+    }                                                   \
+} while (0)
 #define memcached_instance_response_reset(A)     (A)->cursor_active_ = 0
 
 #ifdef __cplusplus


### PR DESCRIPTION
Hello, we ran into a case where `instance->cursor_active_` underflows here:

https://github.com/awesomized/libmemcached/blob/bcc1a6ecf1eadcf69dd9efa02fee69ee63949ca0/src/libmemcached/response.cc#L748

leading to a near-infinite loop here:

https://github.com/awesomized/libmemcached/blob/bcc1a6ecf1eadcf69dd9efa02fee69ee63949ca0/src/libmemcached/get.cc#L190-L192

It seems to occur once every couple hours on a staging host under Apache 2.4 and PHP 7.3 against memcached 1.6.6. We weren't able to pinpoint the exact conditions to reproduce, nor the source of the bug. Maybe a missing `memcached_*_response_increment` or memory corruption?

This appears to be a regression from 1.0.18 which we were running previously.

The patch mitigates but doesn't fix the bug.
