### PR TITLE
Fixed memcached invoke function.

### DIFF
--- a/docs/source/libmemcached/examples.rst
+++ b/docs/source/libmemcached/examples.rst
@@ -18,7 +18,7 @@ Connecting to servers
     "--SERVER=host10.example.com "
     "--SERVER=host11.example.com "
     "--SERVER=host10.example.com";
-  memcached_st *memc= memcached(config_string, strlen(config_string);
+  memcached_st *memc= memcached(config_string, strlen(config_string));
   {
     // ...
   }


### PR DESCRIPTION
while initializing memcached_st, it had a missing `)` for the `memcached` method.