### PR TITLE
Add ENABLE_BACKTRACE option

### DIFF
--- a/CMake/CheckBacktrace.cmake
+++ b/CMake/CheckBacktrace.cmake
@@ -1,4 +1,6 @@
-find_package(Backtrace)
+if(ENABLE_BACKTRACE)
+    find_package(Backtrace)
+endif()
 if(Backtrace_FOUND)
     configure_set(HAVE_BACKTRACE 1)
     configure_define_header(Backtrace_HEADER)

--- a/CMakeConfig.txt
+++ b/CMakeConfig.txt
@@ -51,6 +51,11 @@ set(ENABLE_SANITIZERS "$ENV{ENABLE_SANITIZERS}"
         CACHE STRING "sanitizers to enable (e.g. address;undefined ...)")
 option(ENABLE_SASL          "enable SASL support"
         $ENV{ENABLE_SASL})
+if(NOT DEFINED ENV{ENABLE_BACKTRACE})
+    set(ENV{ENABLE_BACKTRACE} ON)
+endif()
+option(ENABLE_BACKTRACE     "enable backtrace support"
+        $ENV{ENABLE_BACKTRACE})
 option(ENABLE_DTRACE        "enable dtrace support"
         $ENV{ENABLE_DTRACE})
 option(ENABLE_HASH_HSIEH    "enable hsieh hash support"


### PR DESCRIPTION
Allow the end-user to disable backtrace support as it raises the following build failure with https://github.com/ianlancetaylor/libbacktrace:

```
/home/buildroot/autobuild/run/instance-1/output-1/build/libmemcached-1.1.4/src/libmemcached/backtrace.cc: In function 'void custom_backtrace()': /home/buildroot/autobuild/run/instance-1/output-1/build/libmemcached-1.1.4/src/libmemcached/backtrace.cc:41:22: error: 'backtrace' was not declared in this scope; did you mean 'backtrace_full'?
   41 |   int stack_frames = backtrace(backtrace_buffer, MAX_DEPTH);
      |                      ^~~~~~~~~
      |                      backtrace_full
/home/buildroot/autobuild/run/instance-1/output-1/build/libmemcached-1.1.4/src/libmemcached/backtrace.cc:43:25: error: 'backtrace_symbols' was not declared in this scope; did you mean 'backtrace_syminfo'?
   43 |     char **symbollist = backtrace_symbols(backtrace_buffer, stack_frames);
      |                         ^~~~~~~~~~~~~~~~~
      |                         backtrace_syminfo
```

Fixes:
 - http://autobuild.buildroot.org/results/3c5ee59cc032c700e01c4ac84922d749e0370a4a