### PR TITLE
Include netinet/in.h for in_port_t

### DIFF
--- a/include/libmemcached-1.0/struct/server.h
+++ b/include/libmemcached-1.0/struct/server.h
@@ -21,6 +21,10 @@
 #  include <netdb.h>
 #endif
 
+#ifdef HAVE_IN_PORT_T
+#  include <netinet/in.h>
+#endif
+
 #ifdef NI_MAXHOST
 #  define MEMCACHED_NI_MAXHOST NI_MAXHOST
 #else


### PR DESCRIPTION
Same as in the config test in `CMake/_Include.cmake`.
Fixes
~~~
FAILED: src/libmemcachedutil/CMakeFiles/libmemcachedutil.dir/flush.cc.o 
/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=aarch64-none-linux-android28 --sysroot=/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/sysroot -DBUILDING_LIBMEMCACHED -DDEBUG=1 -D_GNU_SOURCE -I/mnt/vcpkg-ci/b/libmemcached-awesome/src/1.1.4-f383202774.clean/src -I/mnt/vcpkg-ci/b/libmemcached-awesome/arm64-android-dbg/src -I/mnt/vcpkg-ci/b/libmemcached-awesome/arm64-android-dbg -I/mnt/vcpkg-ci/b/libmemcached-awesome/src/1.1.4-f383202774.clean/include -I/mnt/vcpkg-ci/b/libmemcached-awesome/arm64-android-dbg/include -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -frtti -fexceptions  -fPIC   -fno-limit-debug-info    -std=gnu++11 -fPIC -Og -ggdb -fno-inline -fno-omit-frame-pointer -fno-eliminate-unused-debug-types -Wall -Wextra -Wdouble-promotion -Wformat=2 -Wnull-dereference -Wshadow -Wunknown-pragmas -fvisibility=hidden -pthread -MD -MT src/libmemcachedutil/CMakeFiles/libmemcachedutil.dir/flush.cc.o -MF src/libmemcachedutil/CMakeFiles/libmemcachedutil.dir/flush.cc.o.d -o src/libmemcachedutil/CMakeFiles/libmemcachedutil.dir/flush.cc.o -c /mnt/vcpkg-ci/b/libmemcached-awesome/src/1.1.4-f383202774.clean/src/libmemcachedutil/flush.cc
In file included from /mnt/vcpkg-ci/b/libmemcached-awesome/src/1.1.4-f383202774.clean/src/libmemcachedutil/flush.cc:16:
In file included from /mnt/vcpkg-ci/b/libmemcached-awesome/src/1.1.4-f383202774.clean/src/libmemcachedutil/common.h:25:
In file included from /mnt/vcpkg-ci/b/libmemcached-awesome/src/1.1.4-f383202774.clean/include/libmemcachedutil-1.0/util.h:18:
In file included from /mnt/vcpkg-ci/b/libmemcached-awesome/src/1.1.4-f383202774.clean/include/libmemcached-1.0/memcached.h:47:
/mnt/vcpkg-ci/b/libmemcached-awesome/src/1.1.4-f383202774.clean/include/libmemcached-1.0/struct/server.h:54:3: error: unknown type name 'in_port_t'; did you mean 'intptr_t'?
   54 |   in_port_t port;
      |   ^~~~~~~~~
      |   intptr_t
~~~