### PR TITLE
Use p9y-targets.cmake

### DIFF
--- a/support/libmemcached-config.cmake.in
+++ b/support/libmemcached-config.cmake.in
@@ -3,6 +3,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 
+include(${CMAKE_CURRENT_LIST_DIR}/p9y-targets.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/libhashkit-targets.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/libmemcached-targets.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/libmemcachedprotocol-targets.cmake)


### PR DESCRIPTION
Complements #133.
Required to use the exported config when built with static libs.