### PR TITLE
Unlock mutex before return if `sasl_startup_function` fails

### DIFF
--- a/src/libmemcached/sasl.cc
+++ b/src/libmemcached/sasl.cc
@@ -180,6 +180,7 @@ memcached_return_t memcached_sasl_authenticate_connection(memcached_instance_st 
   (void) pthread_mutex_lock(&sasl_startup_state_LOCK);
   if (sasl_startup_state != SASL_OK) {
     const char *sasl_error_msg = sasl_errstring(sasl_startup_state, NULL, NULL);
+    (void) pthread_mutex_unlock(&sasl_startup_state_LOCK);
     return memcached_set_error(*server, MEMCACHED_AUTH_PROBLEM, MEMCACHED_AT,
                                memcached_string_make_from_cstr(sasl_error_msg));
   }


### PR DESCRIPTION
When `sasl_startup_state != SASL_OK`, the function returns without unlocking.
If this is not intentional, it seems safer to unlock before returning.