### PR TITLE
check SO_ERROR after nonblocking connect

### DIFF
--- a/src/libmemcached/io.cc
+++ b/src/libmemcached/io.cc
@@ -233,6 +233,19 @@ memcached_return_t memcached_io_poll(memcached_instance_st *inst, int16_t events
       }
     }
     if (pfd.revents & events || (events == IO_POLL_CONNECT && pfd.revents & POLLOUT)) {
+      if (events == IO_POLL_CONNECT) {
+        // Ensure connect actually succeeded
+        memcached_return_t rc = io_sock_err(inst, memcached_literal_param("SO_ERROR after connect"));
+        if (rc != MEMCACHED_SUCCESS) {
+          if (rc == MEMCACHED_TIMEOUT) {
+            // unlikely here, but keep behavior consistent
+            return rc;
+          }
+          // Propagate the real connect error (e.g., ECONNREFUSED)
+          return rc;
+        }
+      }
+
       return MEMCACHED_SUCCESS;
     }
 #if DEBUG
@@ -341,6 +354,13 @@ static bool io_flush(memcached_instance_st *instance, const bool with_flush,
       }
       case ENOTCONN:
       case EPIPE:
+      case ECONNRESET:
+        memcached_quit_server(instance, true);
+        // Report as a connection failure to match test expectations
+        error = memcached_set_error(*instance, MEMCACHED_CONNECTION_FAILURE, MEMCACHED_AT);
+        WATCHPOINT_ASSERT(instance->fd == INVALID_SOCKET);
+        return false;
+
       default:
         memcached_quit_server(instance, true);
         error = memcached_set_errno(*instance, local_errno, MEMCACHED_AT);


### PR DESCRIPTION
On Solaris, several memcached_errors tests failed because the client treated a nonblocking connect as successful as soon as poll/select reported the socket writable, then immediately attempted a send without first checking SO_ERROR. When the connect had actually failed, send() returned EPIPE, which libmemcached reported as MEMCACHED_SYSTEM_ERROR instead of MEMCACHED_CONNECTION_FAILURE. This change fixes the connect race by checking SO_ERROR in IO_POLL_CONNECT before declaring success, and also normalizes mid-connection write failures by mapping EPIPE/ENOTCONN/ECONNRESET to MEMCACHED_CONNECTION_FAILURE (marking the instance dead).