### PR TITLE
Fix ambiguous mutex reference by explicitly using std::mutex

### DIFF
--- a/test/lib/random.cpp
+++ b/test/lib/random.cpp
@@ -5,7 +5,7 @@
 #  include <unistd.h> // getpid()
 #endif
 mt19937_64 rnd_eng;
-mutex rnd_mtx;
+std::mutex rnd_mtx;
 
 void random_setup() {
   using namespace chrono;


### PR DESCRIPTION
On illumos/Solaris you get two different mutex symbols:

C++ standard library

std::mutex


System header

/usr/include/sys/mutex.h
typedef struct mutex { ... } mutex;


Because libmemcached includes system networking headers before <mutex>, the unqualified name mutex becomes ambiguous once <mutex> is included.

GCC 15 is stricter and now errors out instead of picking one.