### PR TITLE
delete returns NOT_FOUND as of 1.6.40

### DIFF
--- a/src/bin/memcapable.cc
+++ b/src/bin/memcapable.cc
@@ -1074,6 +1074,7 @@ static enum test_return receive_error_response(void) {
   char buffer[80];
   execute(receive_line(buffer, sizeof(buffer)));
   verify(strncmp(buffer, "ERROR", 5) == 0 || strncmp(buffer, "CLIENT_ERROR", 12) == 0
+         || strncmp(buffer, "NOT_FOUND", 9) == 0
          || strncmp(buffer, "SERVER_ERROR", 12) == 0);
   return TEST_PASS;
 }


### PR DESCRIPTION
See #161 

With **memcached 1.6.40**

```
$ src/bin/memcapable  -a -h localhost -p  11211
ascii version                           [pass]
ascii quit                              [pass]
ascii verbosity                         [pass]
ascii set                               [pass]
ascii set noreply                       [pass]
ascii get                               [pass]
ascii gets                              [pass]
ascii mget                              [pass]
ascii flush                             [pass]
ascii flush noreply                     [pass]
ascii add                               [pass]
ascii add noreply                       [pass]
ascii replace                           [pass]
ascii replace noreply                   [pass]
ascii cas                               [pass]
ascii cas noreply                       [pass]
ascii delete                            [pass]
ascii delete noreply                    [pass]
ascii incr                              [pass]
ascii incr noreply                      [pass]
ascii decr                              [pass]
ascii decr noreply                      [pass]
ascii append                            [pass]
ascii append noreply                    [pass]
ascii prepend                           [pass]
ascii prepend noreply                   [pass]
ascii stat                              [pass]
All tests passed
```

I add "`NOT_FOUND`" as a possible value for error

Other way is to expect a "`NOT_FOUND`" response, but this will make the test incompatible with older versions

