### PR TITLE
Return MEMCACHED_SERVER_MEMORY_ALLOCATION_FAILURE for binary protocol.

### DIFF
--- a/src/libmemcached/response.cc
+++ b/src/libmemcached/response.cc
@@ -720,7 +720,7 @@ static memcached_return_t binary_read_one_response(memcached_instance_st *instan
       break;
 
     case PROTOCOL_BINARY_RESPONSE_ENOMEM:
-      rc = MEMCACHED_MEMORY_ALLOCATION_FAILURE;
+      rc = MEMCACHED_SERVER_MEMORY_ALLOCATION_FAILURE;
       break;
 
     case PROTOCOL_BINARY_RESPONSE_AUTH_CONTINUE:


### PR DESCRIPTION
To differentiate from MEMCACHED_MEMORY_ALLOCATION_FAILURE and to match the text protocol.